### PR TITLE
Update theme colors and add ngrok validation test

### DIFF
--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -3,13 +3,13 @@ import { createTheme } from '@mui/material/styles';
 const theme = createTheme({
   palette: {
     primary: {
-      main: '#1976d2',
+      main: '#ff5722', // deep orange
     },
     secondary: {
-      main: '#9c27b0',
+      main: '#4caf50', // green
     },
     background: {
-      default: '#f5f5f5',
+      default: '#212121', // dark grey
     },
   },
 });

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 import qr from 'qrcode';
+import { execSync } from 'child_process';
 
 export function findLocalIpAddress(): string {
   let ip = '0.0.0.0';
@@ -23,4 +24,38 @@ export async function generateQRCode(url: string): Promise<string> {
       }
     });
   });
+}
+
+export function checkNgrokInstalled(minVersion = '3.7.0'): boolean {
+  try {
+    const versionOutput = execSync('ngrok version').toString().trim();
+    const versionMatch = versionOutput.match(/(\d+\.\d+\.\d+)/);
+
+    if (!versionMatch) {
+      throw new Error('Unable to parse ngrok version.');
+    }
+
+    const installed = versionMatch[1];
+    const isValid = compareVersions(installed, minVersion) >= 0;
+
+    if (!isValid) {
+      throw new Error(`Ngrok version too old. Installed: ${installed}, Required: ${minVersion}`);
+    }
+
+    console.log(`✅ Ngrok version ${installed} is OK`);
+    return true;
+  } catch (err: any) {
+    console.error(`❌ Ngrok validation failed:`, err.message);
+    return false;
+  }
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1;
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1;
+  }
+  return 0;
 }

--- a/server/test/ngrok.test.ts
+++ b/server/test/ngrok.test.ts
@@ -1,0 +1,8 @@
+import { checkNgrokInstalled } from '../src/utils';
+
+describe('ngrok validation', () => {
+  test('checkNgrokInstalled returns a boolean', () => {
+    const result = checkNgrokInstalled();
+    expect(typeof result).toBe('boolean');
+  });
+});


### PR DESCRIPTION
## Summary
- change MUI theme palette colors
- add ngrok version validation helper
- include new Jest test for ngrok validation

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6854ae3083148332ad0b73d4cd6d3f79